### PR TITLE
Fix: Production Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:server": "export NODE_ENV=test || SET \"NODE_ENV=test\" && nyc --reporter=html --reporter=text mocha timeout 15000 --compilers js:babel-register server/test/**/*.test.js",
     "test:client": "jest /client --coverage",
     "test": "npm run test:server",
-    "build": "NODE_ENV='production' webpack -p",
+    "build": "NODE_ENV=production webpack -p",
     "dev": "nodemon --watch server --exec babel-node -- server/index.js",
     "prod:start": "export NODE_ENV=production || SET \"NODE_ENV=production\" && npm start",
     "prod:build-start": "npm run build && npm run prod:start",

--- a/webpack.deployment.config.js
+++ b/webpack.deployment.config.js
@@ -18,9 +18,6 @@ module.exports = {
     publicPath: '/',
     filename: 'bundle.js',
   },
-  devServer: {
-    contentBase: path.resolve(__dirname, 'dist')
-  },
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),
     new webpack.DefinePlugin(GLOBALS),


### PR DESCRIPTION
#### What does this PR do?
Configure the production build of React
#### Description of Task to be completed?
In the webpack.deployment.config.js file enable the configuration of the production build of react. Remove devServer script found in deployment webpack build
#### How should this be manually tested?
 If you visit a site with React in production mode, the react developer tools icon will have a dark background.
#### Any background context you want to provide?
nil
#### What are the relevant pivotal tracker stories?
nil
#### Screenshots (if appropriate)
nil
#### Questions:
nil