### PR TITLE
BugFix: prevent error message from displaying when submit button is clicked t…

### DIFF
--- a/client/__tests__/actions/authActions.test.js
+++ b/client/__tests__/actions/authActions.test.js
@@ -33,22 +33,6 @@ describe('Auth Actions', () => {
     });
   });
 
-  it('creates SIGNUP_FAILURE when signup action fails', () => {
-    moxios.stubRequest('/api/v1/signup', {
-      status: 400,
-      response: 'An error occured'
-    });
-
-    const expectedActions = [
-      { type: types.SIGNUP_FAILURE }
-    ];
-
-    const store = mockStore({});
-    return store.dispatch(signup({})).then(() => {
-      expect(store.getActions()).to.eql(expectedActions);
-    });
-  });
-
   it('creates LOGIN_SUCCESS when login action is successful', () => {
     const { authResponse } = mockData;
     moxios.stubRequest('/api/v1/signin', {

--- a/client/src/actions/authActions.js
+++ b/client/src/actions/authActions.js
@@ -51,10 +51,6 @@ const signup = userDetails => dispatch => axios
     localStorage.setItem('jwtToken', token);
     setAuthorizationToken(token);
     dispatch(signupSuccess(response.data.user));
-  })
-  .catch((error) => {
-    dispatch(signupFailure());
-    toastr.error(error.response.data.message);
   });
 
 /**

--- a/client/src/components/auth/SignupPage.jsx
+++ b/client/src/components/auth/SignupPage.jsx
@@ -30,6 +30,7 @@ export class SignupPage extends React.Component {
       password: '',
       confirmpassword: '',
       errors: {},
+      disabled: false
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -67,12 +68,16 @@ export class SignupPage extends React.Component {
   handleSubmit(event) {
     event.preventDefault();
     if (this.isValid()) {
-      this.setState({ errors: {} })
+      this.setState({ errors: {}, disabled: true })
       this.props.signup(this.state).then(() => {
         if (this.props.isAuthenticated) {
           toastr.success('Welcome to PostIt');
         }
-      });
+      })
+      .catch((error) => {
+        toastr.error(error.response.data.message);
+        return this.setState({ disabled: false });
+      })
     }
   }
 
@@ -145,6 +150,7 @@ export class SignupPage extends React.Component {
                     "btn waves-effect waves-light blue darken-2 signup-button"
                     onClick={this.handleSubmit}
                     text="create account"
+                    disabled={this.state.disabled}
                   />
                 </div>
               </form>
@@ -171,7 +177,8 @@ SignupPage.propTypes = {
  * @returns {object} contains sections of the redux store
  */
 const mapStateToProps = state => ({
-  isAuthenticated: state.auth.isAuthenticated
+  isAuthenticated: state.auth.isAuthenticated,
+  isLoading: state.ajaxCallsInProgress
 });
 
 /**


### PR DESCRIPTION
#### What does this PR do?
On user signup if a user click the submit button twice the request is made twice resulting in an error message being displayed once the user access the dashboard page
#### Description of Task to be completed?
Disable the submit button once user has clicked it once.
#### How should this be manually tested?
On clicking the submit button twice, Only the first click should trigger an action.
#### Any background context you want to provide?
nil
#### What are the relevant pivotal tracker stories?
nil
#### Screenshots (if appropriate)
nil
#### Questions:
